### PR TITLE
Neo4j 8.x and Core 7.x support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ language: ruby
 jdk:
   - oraclejdk8
 rvm:
-  - 2.0.0
+  - 2.1.9
   - 2.2.4
   - 2.3.1
 env:

--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,5 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'activesupport', '~> 4.2' if RUBY_VERSION.to_f < 2.2
+
+gem 'neo4j', '~> 8.0.0.alpha.2'

--- a/lib/neo4j/active_node/spatial.rb
+++ b/lib/neo4j/active_node/spatial.rb
@@ -8,7 +8,7 @@ module Neo4j
       def add_to_spatial_index(index_name = nil)
         index = index_name || self.class.spatial_index_name
         fail 'index name not found' unless index
-        Neo4j::Session.current.add_node_to_spatial_index(index, self)
+        ActiveBase.current_session.add_node_to_spatial_index(index, self)
       end
 
       module ClassMethods
@@ -33,7 +33,7 @@ module Neo4j
         def spatial_match(var, params_string, spatial_index = nil)
           index = model.spatial_index_name || spatial_index
           fail 'Cannot query without index. Set index in model or as third argument.' unless index
-          Neo4j::Session.current.query
+          Neo4j::ActiveBase.new_query
             .start("#{var} = node:#{index}({spatial_params})")
             .proxy_as(model, var)
             .params(spatial_params: params_string)

--- a/lib/neo4j/cypher_session.rb
+++ b/lib/neo4j/cypher_session.rb
@@ -1,0 +1,28 @@
+module Neo4j
+  module Core
+    module Spatial
+      module CypherSession
+        %w(
+          spatial?
+          spatial_plugin
+          add_point_layer
+          add_editable_layer
+          get_layer
+          add_geometry_to_layer
+          edit_geometry_from_layer
+          add_node_to_layer
+          find_geometries_in_bbox
+          find_geometries_within_distance
+          create_spatial_index
+          add_node_to_spatial_index
+        ).each do |method, &_block|
+          define_method(method) do |*args, &block|
+            @adaptor.send(method, *args, &block)
+          end
+        end
+      end
+    end
+  end
+end
+
+Neo4j::Core::CypherSession.__send__(:include, Neo4j::Core::Spatial::CypherSession)

--- a/lib/neo4j/http_adaptor.rb
+++ b/lib/neo4j/http_adaptor.rb
@@ -1,0 +1,138 @@
+require 'neo4j/core/cypher_session/adaptors/http'
+
+module Neo4j
+  module Core
+    module Spatial
+      module HTTPAdaptor
+        def spatial?
+          connection.get('/db/data/ext/SpatialPlugin').status == 200
+        end
+
+        def spatial_plugin
+          connection.get('/db/data/ext/SpatialPlugin').body
+        end
+
+        def add_point_layer(layer, lat = nil, lon = nil)
+          options = {
+            layer: layer,
+            lat: lat || 'lat',
+            lon: lon || 'lon'
+          }
+
+          spatial_post('/ext/SpatialPlugin/graphdb/addSimplePointLayer', options)
+        end
+
+        def add_editable_layer(layer, format = 'WKT', node_property_name = 'wkt')
+          options = {
+            layer: layer,
+            format: format,
+            nodePropertyName: node_property_name
+          }
+
+          spatial_post('/ext/SpatialPlugin/graphdb/addEditableLayer', options)
+        end
+
+        def get_layer(layer)
+          options = {
+            layer: layer
+          }
+          spatial_post('/ext/SpatialPlugin/graphdb/getLayer', options)
+        end
+
+        def add_geometry_to_layer(layer, geometry)
+          options = {
+            layer: layer,
+            geometry: geometry
+          }
+          spatial_post('/ext/SpatialPlugin/graphdb/addGeometryWKTToLayer', options)
+        end
+
+        def edit_geometry_from_layer(layer, geometry, node)
+          options = {
+            layer: layer,
+            geometry: geometry,
+            geometryNodeId: get_id(node)
+          }
+          spatial_post('/ext/SpatialPlugin/graphdb/updateGeometryFromWKT', options)
+        end
+
+        def add_node_to_layer(layer, node)
+          options = {
+            layer: layer,
+            node: "/db/data/node/#{node.neo_id}"
+          }
+          spatial_post('/ext/SpatialPlugin/graphdb/addNodeToLayer', options)
+        end
+
+        def find_geometries_in_bbox(layer, minx, maxx, miny, maxy)
+          options = {
+            layer: layer,
+            minx: minx,
+            maxx: maxx,
+            miny: miny,
+            maxy: maxy
+          }
+          spatial_post('/ext/SpatialPlugin/graphdb/findGeometriesInBBox', options)
+        end
+
+        def find_geometries_within_distance(layer, pointx, pointy, distance)
+          options = {
+            layer: layer,
+            pointX: pointx,
+            pointY: pointy,
+            distanceInKm: distance
+          }
+          spatial_post('/ext/SpatialPlugin/graphdb/findGeometriesWithinDistance', options)
+        end
+
+        def create_spatial_index(name, type = nil, lat = nil, lon = nil)
+          options = {
+            name: name,
+            config: {
+              provider: 'spatial',
+              geometry_type: type || 'point',
+              lat: lat || 'lat',
+              lon: lon || 'lon'
+            }
+          }
+          spatial_post('/index/node', options)
+        end
+
+        def add_node_to_spatial_index(index, node)
+          options = {
+            uri: "/#{get_id(node)}",
+            key: 'k',
+            value: 'v'
+          }
+          spatial_post("/index/node/#{index}", options)
+        end
+
+        private
+
+        def spatial_post(path, options)
+          connection.post("/db/data/#{path}", options).body
+        end
+
+        def connection
+          @requestor.instance_variable_get(:@faraday)
+        end
+
+        def get_id(id)
+          return id.neo_id if id.respond_to?(:neo_id)
+          case id
+          when Array
+            get_id(id.first)
+          when Hash
+            id[:self].split('/').last
+          when String
+            id.split('/').last
+          else
+            id
+          end
+        end
+      end
+    end
+  end
+end
+
+Neo4j::Core::CypherSession::Adaptors::HTTP.include Neo4j::Core::Spatial::HTTPAdaptor

--- a/lib/neo4jrb_spatial.rb
+++ b/lib/neo4jrb_spatial.rb
@@ -1,3 +1,8 @@
 require 'neo4jrb_spatial/version'
+# New Cypher API
+require 'neo4j/http_adaptor'
+require 'neo4j/cypher_session'
+# Old cypher API
 require 'neo4j/spatial'
+# Neo4jrb OGM
 require 'neo4j/active_node/spatial'

--- a/neo4jrb_spatial.gemspec
+++ b/neo4jrb_spatial.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec'
   spec.add_development_dependency 'pry'
 
-  spec.add_dependency 'neo4j', '>= 5.0.1', '< 8'
+  spec.add_dependency 'neo4j', '>= 5.0.1'
   spec.add_dependency 'neo4j-core', '>= 5.0.1'
   spec.add_dependency 'neo4j-rake_tasks', '~> 0.3'
 end

--- a/spec/active_node_spec.rb
+++ b/spec/active_node_spec.rb
@@ -1,0 +1,31 @@
+describe 'ActiveNode integration' do
+  let(:node) { Restaurant.create(name: "Chris's Restaurant", lat: 60.1, lon: 15.2) }
+  let(:outside_node) { Restaurant.create(name: 'Lily Thai', lat: 59.0, lon: 14.9) }
+  before do
+    stub_const('Restaurant', Class.new do
+      include Neo4j::ActiveNode
+      include Neo4j::ActiveNode::Spatial
+      spatial_index 'restaurants'
+      property :name
+      property :lat
+      property :lon
+    end)
+
+    Restaurant.delete_all
+    [node, outside_node].each(&:add_to_spatial_index)
+  end
+
+  let(:match) { Restaurant.all.spatial_match(:r, 'withinDistance:[60.0,15.0,100.0]') }
+
+  it 'is a QueryProxy' do
+    expect(match).to respond_to(:to_cypher)
+  end
+
+  it 'matches to the node in the spatial index' do
+    expect(match.first).to eq node
+  end
+
+  it 'only returns expected nodes' do
+    expect(match.to_a).not_to include(outside_node)
+  end
+end

--- a/spec/active_node_spec.rb
+++ b/spec/active_node_spec.rb
@@ -2,6 +2,7 @@ describe 'ActiveNode integration', type: :active_model do
   let(:node) { Restaurant.create(name: "Chris's Restaurant", lat: 60.1, lon: 15.2) }
   let(:outside_node) { Restaurant.create(name: 'Lily Thai', lat: 59.0, lon: 14.9) }
   before do
+    Neo4j::ActiveBase.current_session.create_spatial_index('restaurants')
     stub_active_node_class('Restaurant') do
       include Neo4j::ActiveNode::Spatial
       spatial_index 'restaurants'

--- a/spec/active_node_spec.rb
+++ b/spec/active_node_spec.rb
@@ -1,15 +1,14 @@
-describe 'ActiveNode integration' do
+describe 'ActiveNode integration', type: :active_model do
   let(:node) { Restaurant.create(name: "Chris's Restaurant", lat: 60.1, lon: 15.2) }
   let(:outside_node) { Restaurant.create(name: 'Lily Thai', lat: 59.0, lon: 14.9) }
   before do
-    stub_const('Restaurant', Class.new do
-      include Neo4j::ActiveNode
+    stub_active_node_class('Restaurant') do
       include Neo4j::ActiveNode::Spatial
       spatial_index 'restaurants'
       property :name
       property :lat
       property :lon
-    end)
+    end
 
     Restaurant.delete_all
     [node, outside_node].each(&:add_to_spatial_index)

--- a/spec/old_api_spec.rb
+++ b/spec/old_api_spec.rb
@@ -1,0 +1,169 @@
+require 'spec_helper'
+
+describe 'Old neo4j-core API' do
+  def create_server_session
+    Neo4j::Session.open(:server_db, server_url)
+  end
+
+  before do
+    curr_session = Neo4j::Session.current
+    curr_session.close if curr_session && !curr_session.is_a?(Neo4j::Server::CypherSession)
+    Neo4j::Session.current || create_server_session
+  end
+
+  let(:neo) { Neo4j::Session.current }
+
+  describe 'find the spatial plugin' do
+    it 'can get a description of the spatial plugin' do
+      si = neo.spatial_plugin
+      expect(si).not_to be_nil
+      expect(si[:graphdb][:addEditableLayer]).not_to be_nil
+    end
+  end
+
+  describe 'add a point layer' do
+    it 'can add a simple point layer' do
+      pl = neo.add_point_layer('restaurants')
+      expect(pl).not_to be_nil
+      expect(pl.first[:data][:layer]).to eq('restaurants')
+      expect(pl.first[:data][:geomencoder_config]).to eq('lon:lat')
+    end
+
+    it 'can add a simple point layer with lat and long' do
+      pl = neo.add_point_layer('coffee_shops', 'latitude', 'longitude')
+      expect(pl).not_to be_nil
+      expect(pl.first[:data][:layer]).to eq('coffee_shops')
+      expect(pl.first[:data][:geomencoder_config]).to eq('longitude:latitude')
+    end
+  end
+
+  describe 'add an editable layer' do
+    it 'can add an editable layer' do
+      el = neo.add_editable_layer('zipcodes', 'WKT', 'wkt')
+      expect(el).not_to be_nil
+      expect(el.first[:data][:layer]).to eq('zipcodes')
+      expect(el.first[:data][:geomencoder_config]).to eq('wkt')
+    end
+  end
+
+  describe 'get a spatial layer' do
+    it 'can get a layer' do
+      sl = neo.get_layer('restaurants')
+      expect(sl).not_to be_nil
+      expect(sl.first[:data][:layer]).to eq('restaurants')
+    end
+  end
+
+  describe 'create a spatial index' do
+    it 'can create a spatial index' do
+      index = neo.create_spatial_index('restaurants')
+      expect(index[:provider]).to eq('spatial')
+      expect(index[:geometry_type]).to eq('point')
+      expect(index[:lat]).to eq('lat')
+      expect(index[:lon]).to eq('lon')
+    end
+  end
+
+  describe 'add geometry to spatial layer' do
+    it 'can add a geometry' do
+      geometry = 'LINESTRING (15.2 60.1, 15.3 60.1)'
+      geo = neo.add_geometry_to_layer('zipcodes', geometry)
+      expect(geo).not_to be_nil
+      expect(geo.first[:data][:wkt]).to eq(geometry)
+    end
+  end
+
+  describe 'update geometry from spatial layer' do
+    it 'can update a geometry' do
+      geometry = 'LINESTRING (15.2 60.1, 15.3 60.1)'
+      geo = neo.add_geometry_to_layer('zipcodes', geometry)
+      expect(geo).not_to be_nil
+      expect(geo.first[:data][:wkt]).to eq(geometry)
+      geometry = 'LINESTRING (14.7 60.1, 15.3 60.1)'
+      existing_geo = neo.edit_geometry_from_layer('zipcodes', geometry, geo)
+      expect(existing_geo.first[:data][:wkt]).to eq(geometry)
+      expect(existing_geo.first[:self].split('/').last.to_i).to eq(geo.first[:self].split('/').last.to_i)
+    end
+  end
+
+  describe 'add a node to a layer' do
+    it 'can add a node to a simple point layer' do
+      properties = {name: "Max's Restaurant", lat: 41.8819, lon: 87.6278}
+      node = Neo4j::Node.create(properties, :Restaurant)
+      expect(node).not_to be_nil
+      added = neo.add_node_to_layer('restaurants', node)
+      expect(added.first[:data][:lat]).to eq(properties[:lat])
+      expect(added.first[:data][:lon]).to eq(properties[:lon])
+
+      added = neo.add_node_to_spatial_index('restaurants', node)
+      expect(added[:data][:lat]).to eq(properties[:lat])
+      expect(added[:data][:lon]).to eq(properties[:lon])
+    end
+  end
+
+  describe 'find geometries in a bounding box' do
+    it 'can find a geometry in a bounding box' do
+      properties = {name: "Max's Restaurant", lat: 41.8819, lon: 87.6278}
+      nodes = neo.find_geometries_in_bbox('restaurants', 87.5, 87.7, 41.7, 41.9)
+      expect(nodes).not_to be_empty
+      result = nodes.find { |node| node[:data][:name] == "Max's Restaurant" }
+      expect(result[:data][:lat]).to eq(properties[:lat])
+      expect(result[:data][:lon]).to eq(properties[:lon])
+    end
+
+    it 'can find a geometry in a bounding box using cypher' do
+      properties = {lat: 60.1, lon: 15.2}
+      neo.create_spatial_index('geombbcypher', 'point', 'lat', 'lon')
+      node = Neo4j::Node.create(properties, :dummy)
+      neo.add_node_to_spatial_index('geombbcypher', node)
+      existing_node = neo.query.start("node = node:geombbcypher('bbox:[15.0,15.3,60.0,60.2]')").pluck(:node).first
+      expect(existing_node).not_to be_nil
+      expect(existing_node.props[:lat]).to eq(properties[:lat])
+      expect(existing_node.props[:lon]).to eq(properties[:lon])
+    end
+
+    it 'can find a geometry in a bounding box using cypher two' do
+      properties = {lat: 60.1, lon: 15.2}
+      neo.create_spatial_index('geombbcypher2', 'point', 'lat', 'lon')
+      node = Neo4j::Node.create(properties)
+      neo.add_node_to_spatial_index('geombbcypher2', node)
+      existing_node = node.query.start("node = node:geombbcypher2('bbox:[15.0,15.3,60.0,60.2]')").pluck(:node).first
+      expect(existing_node).not_to be_nil
+      expect(existing_node.props[:lat]).to eq(properties[:lat])
+      expect(existing_node.props[:lon]).to eq(properties[:lon])
+    end
+  end
+
+  describe 'find geometries within distance' do
+    it 'can find a geometry within distance' do
+      properties = {name: "Max's Restaurant", lat: 41.8819, lon: 87.6278}
+      nodes = neo.find_geometries_within_distance('restaurants', 87.627, 41.881, 10)
+      expect(nodes).not_to be_empty
+      result = nodes.find { |node| node[:data][:name] == "Max's Restaurant" }
+      expect(result[:data][:lat]).to eq(properties[:lat])
+      expect(result[:data][:lon]).to eq(properties[:lon])
+    end
+
+    it 'can find a geometry within distance using cypher' do
+      properties = {lat: 60.1, lon: 15.2}
+      neo.create_spatial_index('geowdcypher', 'point', 'lat', 'lon')
+      node = Neo4j::Node.create(properties)
+      neo.add_node_to_spatial_index('geowdcypher', node)
+      existing_node = neo.query.start('n = node:geowdcypher({bbox})').params(bbox: 'withinDistance:[60.0,15.0,100.0]').pluck(:n).first
+      expect(existing_node).not_to be_nil
+      expect(existing_node.props[:lat]).to eq(properties[:lat])
+      expect(existing_node.props[:lon]).to eq(properties[:lon])
+    end
+
+    it 'can find a geometry within distance using cypher 2'  do
+      properties = {lat: 60.1, lon: 15.2}
+      neo.create_spatial_index('geowdcypher2', 'point', 'lat', 'lon')
+      node = Neo4j::Node.create(properties)
+      neo.add_node_to_spatial_index('geowdcypher2', node)
+      existing_node = neo.query.start('n = node:geowdcypher2({bbox})').params(bbox: 'withinDistance:[60.0,15.0,100.0]').pluck(:n).first
+      expect(existing_node).not_to be_nil
+      expect(existing_node.props[:lat]).to eq(properties[:lat])
+      expect(existing_node.props[:lon]).to eq(properties[:lon])
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -30,11 +30,12 @@ module ActiveNodeRelStubHelpers
   end
 
   def active_node_class(class_name, with_constraint = true, &block)
-    named_class(class_name) do
+    klass = named_class(class_name) do
       include Neo4j::ActiveNode
 
       module_eval(&block) if block
-    end.tap { |model| create_id_property_constraint(model, with_constraint) }
+    end
+    klass.tap { |model| create_id_property_constraint(model, with_constraint) }
   end
 
   def create_id_property_constraint(model, with_constraint)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,16 +1,12 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'rspec'
 require 'json'
-require 'neo4j-core'
 require 'neo4j'
+require 'neo4j-core'
 require 'neo4jrb_spatial'
 
 def server_url
   ENV['NEO4J_URL'] || 'http://localhost:7474'
-end
-
-def create_server_session
-  Neo4j::Session.open(:server_db, server_url)
 end
 
 def clear_model_memory_caches
@@ -19,16 +15,33 @@ def clear_model_memory_caches
   Neo4j::ActiveNode::Labels.clear_wrapped_models
 end
 
+TEST_SESSION_MODE = RUBY_PLATFORM == 'java' ? :embedded : :http
+
+session_adaptor = case TEST_SESSION_MODE
+                  when :embedded
+                    Neo4j::Core::CypherSession::Adaptors::Embedded.new(EMBEDDED_DB_PATH, impermanent: true, auto_commit: true, wrap_level: :proc)
+                  when :http
+                    server_url = ENV['NEO4J_URL'] || 'http://localhost:7474'
+                    server_username = ENV['NEO4J_USERNAME'] || 'neo4j'
+                    server_password = ENV['NEO4J_PASSWORD'] || 'neo4jrb rules, ok?'
+
+                    basic_auth_hash = {username: server_username, password: server_password}
+
+                    case URI(server_url).scheme
+                    when 'http'
+                      Neo4j::Core::CypherSession::Adaptors::HTTP.new(server_url, basic_auth: basic_auth_hash, wrap_level: :proc)
+                    when 'bolt'
+                      Neo4j::Core::CypherSession::Adaptors::Bolt.new(server_url, wrap_level: :proc) # , logger_level: Logger::DEBUG)
+                    else
+                      fail "Invalid scheme for NEO4J_URL: #{scheme} (expected `http` or `bolt`)"
+                    end
+                  end
+
+Neo4j::ActiveBase.current_adaptor = session_adaptor
+
 RSpec.configure do |c|
   c.before(:suite) do
-    create_server_session
-    Neo4j::Session.current.query('MATCH (n) OPTIONAL MATCH (n)-[r]-() DELETE n, r')
-  end
-
-  c.before do
-    curr_session = Neo4j::Session.current
-    curr_session.close if curr_session && !curr_session.is_a?(Neo4j::Server::CypherSession)
-    Neo4j::Session.current || create_server_session
+    Neo4j::ActiveBase.current_session.query('MATCH (n) OPTIONAL MATCH (n)-[r]-() DELETE n, r')
   end
 
   c.after(:each) do


### PR DESCRIPTION
It's pretty much a refactor to support the new `neo4j-core` API and the `ActiveNode` integration.

It keeps support for the old neo4j-core API. (see `old_api_spec.rb`)
It implements the spatial methods monkey patching the `HTTP` adaptor of the new cypher API.
I think we should create a new major version for this, like 2.x

Pings: @subvertallchris @cheerfulstoic 
