### PR TITLE
Upgraded neo4j dependencies to be able to use neo4jrb_spatial with rails 5.1

### DIFF
--- a/neo4jrb_spatial.gemspec
+++ b/neo4jrb_spatial.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec'
   spec.add_development_dependency 'pry'
 
-  spec.add_dependency 'neo4j', '>= 8.0.6', '<= 8.0.15'
-  spec.add_dependency 'neo4j-core', '>= 7', '< 7.1.0'
+  spec.add_dependency 'neo4j', '>= 8.0.6', '<= 8.3.4'
+  spec.add_dependency 'neo4j-core', '>= 7.2.2'
   spec.add_dependency 'neo4j-rake_tasks', '~> 0.3'
 end

--- a/neo4jrb_spatial.gemspec
+++ b/neo4jrb_spatial.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'pry'
 
   spec.add_dependency 'neo4j', '>= 8.0.6', '<= 8.3.4'
+  spec.add_dependency 'activemodel', '<= 5.1.6'
   spec.add_dependency 'neo4j-core', '>= 7.2.2'
   spec.add_dependency 'neo4j-rake_tasks', '~> 0.3'
 end


### PR DESCRIPTION
I just upgraded dependency restrictions and didn't notice for now any error. 